### PR TITLE
feat: Add sound pulses for enemy hit/death and arrow disappearance

### DIFF
--- a/char/arrow.gd
+++ b/char/arrow.gd
@@ -32,6 +32,7 @@ func setup_signals():
 
 func start_lifetime_timer():
 	await get_tree().create_timer(lifetime).timeout
+	SoundPulse.spawn(get_tree().current_scene, 600, global_position, 0.5, 0.15, 0.2)
 	queue_free()
 
 # === MOVIMENTO ===
@@ -53,6 +54,7 @@ func check_min_velocity():
 		return
 
 	if velocity.length() < min_velocity_before_despawn:
+		SoundPulse.spawn(get_tree().current_scene, 600, global_position, 0.5, 0.15, 0.2)
 		queue_free()
 
 # === INTERFACE EXTERNA ===

--- a/char/enemy.gd
+++ b/char/enemy.gd
@@ -61,13 +61,14 @@ func _flip_direction():
 # === VIDA ===
 func take_damage(amount: int):
 	current_health -= amount
-	SoundPulse.spawn(get_tree().current_scene, randf_range(1000, 1500), global_position, 1)
+	SoundPulse.spawn(get_tree().current_scene, 250, global_position, 1)
 	print("💥 inimigo atingido! vida: ", current_health)
 	update_health_label()
 	if current_health <= 0:
 		die()
 
 func die():
+	SoundPulse.spawn(get_tree().current_scene, randf_range(1000, 1500), global_position, 1)
 	queue_free()
 
 func update_health_label():


### PR DESCRIPTION
This commit implements the following changes:

- Enemy hit: Generates a small sound pulse (radius 250).
- Enemy death: Generates a large sound pulse (radius 1000-1500).
- Arrow disappearance: Generates a medium sound pulse (radius 600) when the arrow is removed due to its lifetime expiring or its velocity becoming too low.

These changes enhance the game's feedback to you by providing auditory cues for these events.